### PR TITLE
bike-sharing: Call the mlflow library after imports

### DIFF
--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -31,25 +31,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 39,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022/11/18 19:24:12 INFO mlflow.tracking.fluent: Experiment with name 'bike-sharing-exp' does not exist. Creating a new experiment.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Set up an experiment with set_exp from ezmllib.mlflow\n",
-    "experiment_name = 'bike-sharing-exp'\n",
-    "mlflow.set_experiment(experiment_name)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "6dR-JRDBngFJ"
@@ -123,6 +104,25 @@
     "if os.path.exists(\"model_artifacts\"):\n",
     "    os.system(\"rm -rf model_artifacts\")\n",
     "os.mkdir(\"model_artifacts\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022/11/18 19:24:12 INFO mlflow.tracking.fluent: Experiment with name 'bike-sharing-exp' does not exist. Creating a new experiment.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set up an experiment with set_exp from ezmllib.mlflow\n",
+    "experiment_name = 'bike-sharing-exp'\n",
+    "mlflow.set_experiment(experiment_name)"
    ]
   },
   {


### PR DESCRIPTION
Fix the issue of calling the `mlflow` library before importing it.