### PR TITLE
Change the default docker images

### DIFF
--- a/E2E-Demos/Question-Answering/01.create-vectorstore.ipynb
+++ b/E2E-Demos/Question-Answering/01.create-vectorstore.ipynb
@@ -84,11 +84,13 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bafbff81-1b65-41fb-9d65-a26e88779d37",
    "metadata": {
     "tags": []
    },
+   "outputs": [],
    "source": [
     "def load_docs(source_dir: str) -> list:\n",
     "    \"\"\"Load all documents in a the given directory.\"\"\"\n",

--- a/E2E-Demos/Question-Answering/02.serve-vectorstore.ipynb
+++ b/E2E-Demos/Question-Answering/02.serve-vectorstore.ipynb
@@ -137,8 +137,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "predictor_image = (input(\"Enter the name of the predictor image (default: gcr.io/mapr-252711/ezua-demos/vectorstore:v0.1.0): \")\n",
-    "                   or \"gcr.io/mapr-252711/ezua-demos/vectorstore:v0.1.0\")"
+    "predictor_image = (input(\"Enter the name of the predictor image (default: dpoulopoulos/vectorstore:b98a87f): \")\n",
+    "                   or \"dpoulopoulos/vectorstore:b98a87f\")"
    ]
   },
   {

--- a/E2E-Demos/Question-Answering/04.serve-llm.ipynb
+++ b/E2E-Demos/Question-Answering/04.serve-llm.ipynb
@@ -89,10 +89,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "PREDICTOR_IMAGE = (input(\"Enter the name of the predictor image (default: gcr.io/mapr-252711/ezua-demos/llm-predictor:v0.1.0): \")\n",
-    "                   or \"gcr.io/mapr-252711/ezua-demos/llm-predictor:v0.1.0\")\n",
-    "TRANSFORMER_IMAGE = (input(\"Enter the name of the transformer image (default: gcr.io/mapr-252711/ezua-demos/llm-transformer:v0.1.0): \")\n",
-    "                     or \"gcr.io/mapr-252711/ezua-demos/llm-transformer:v0.1.0\")"
+    "PREDICTOR_IMAGE = (input(\"Enter the name of the predictor image (default: dpoulopoulos/llm-predictor:b98a87f): \")\n",
+    "                   or \"dpoulopoulos/llm-predictor:b98a87f\")\n",
+    "TRANSFORMER_IMAGE = (input(\"Enter the name of the transformer image (default: dpoulopoulos/llm-transformer:b98a87f): \")\n",
+    "                     or \"dpoulopoulos/llm-transformer:b98a87f\")"
    ]
   },
   {


### PR DESCRIPTION
Use a set of docker images pulled from the public Docker Hub registry, since not all new clusters have access to pull images from gcr.io by default.