### PR TITLE
MLFlow Example : Add RBAC 

### DIFF
--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -1613,7 +1613,7 @@
     "permission = #\"READ\", \"EDIT\", \"MANAGE\", \"NO_PERMISSIONS\"\n",
     "exp_id = mlflow.get_experiment_by_name(experiment_name).experiment_id\n",
     "\n",
-    "client = AuthServiceClient(\"http://mlflow.mlflow.svc.cluster.local:5000\")"
+    "client = AuthServiceClient(mlflow.get_tracking_uri())"
    ]
   },
   {

--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -1589,6 +1589,94 @@
     "    figsize=(15, 15),\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Role Based Access Control\n",
+    "\n",
+    "By default, users recieve `MANAGE` permissions if they create an object, `NO_PERMISSIONS` otherwise. A full breakdown of all roles and their access is described [here](https://mlflow.org/docs/latest/auth/index.html#permissions)\n",
+    "\n",
+    "To share experiments/models, MLFlow provides an `AuthServiceCLient` implementing CRUD functionality for `experiment_permission` and `model_permission` objects. `AuthServiceClient` is documented [here](https://mlflow.org/docs/latest/auth/python-api.html#mlflow.server.auth.client.AuthServiceClient)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mlflow.server.auth.client import AuthServiceClient\n",
+    "\n",
+    "user = #\" USERNAME\"\n",
+    "permission = #\"READ\", \"EDIT\", \"MANAGE\", \"NO_PERMISSIONS\"\n",
+    "exp_id = mlflow.get_experiment_by_name(experiment_name).experiment_id\n",
+    "\n",
+    "client = AuthServiceClient(\"http://mlflow.mlflow.svc.cluster.local:5000\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Creating Permission"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "permission = \"READ\"\n",
+    "exp_permission = client.create_experiment_permission(exp_id, user, permission)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Modifying Permission"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "permission = \"EDIT\"\n",
+    "\n",
+    "exp_permission = client.update_experiment_permission(exp_id, user, permission)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "permission = \"NO_PERMISSIONS\"\n",
+    "\n",
+    "exp_permission = client.update_experiment_permission(exp_id, user, permission)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Delete Permissions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exp_permission = client.delete_experiment_permission(exp_id, user)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR adds a Role Based Access Control section to the bike sharing example, illustrating how the authserviceclient can be utilized to manage experiment and registered model permissions for both admin and regular ezua users. 

![image](https://github.com/HPEEzmeral/ezua-tutorials/assets/143547665/57c8d0f8-94d2-4a85-9c22-b0d9cf0bd22e)
