### PR TITLE
EZAF 3502: Create spark secret through notebook for s3 proxy

### DIFF
--- a/Data-Analytics/Spark-S3-secret/README.md
+++ b/Data-Analytics/Spark-S3-secret/README.md
@@ -1,0 +1,15 @@
+# EZAF Spark Secret Creation
+
+This notebook example provides a way to showcase how to create s3 secret consumed by spark application YAML.
+
+### Run the spark secret creation notebook example
+
+The example will read the environment values and create s3 secret in the current user's namespace.
+We should reference this secret in spark application YAML as follows:
+
+```
+spec:
+  sparkConf:
+    spark.mapr.extraconf.secret: "<k8s-secret-name>"
+```
+

--- a/Data-Analytics/Spark-S3-secret/README.md
+++ b/Data-Analytics/Spark-S3-secret/README.md
@@ -1,11 +1,12 @@
 # EZAF Spark Secret Creation
 
-This notebook example provides a way to showcase how to create s3 secret consumed by spark application YAML.
+This notebook example provides a way to showcase how to create s3 secret consumed by spark application YAML
+and Livy session.
 
 ### Run the spark secret creation notebook example
 
 The example will read the environment values and create s3 secret in the current user's namespace.
-We should reference this secret in spark application YAML as follows:
+This secret can be referenced later via 'spark.mapr.extraconf.secret' spark config option:
 
 ```
 spec:

--- a/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
+++ b/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Spark S3 proxy secret\n",
+    "### This notebook demonstrates an example of creation of s3 secret for spark application consumption."
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "\n",
+    "def deploy_s3_secret(namespace, spark_secret):\n",
+    "    try:\n",
+    "        # Run kubectl apply command using subprocess\n",
+    "        subprocess.run(['kubectl', 'delete', 'secret', spark_secret, '-n', namespace], check=False)\n",
+    "        subprocess.run(['kubectl', 'create', 'secret', 'generic', spark_secret, '-n', namespace , '--from-file=spark-defaults.conf'], check=True)\n",
+    "        print(\"Secret creation successful!\")\n",
+    "    except subprocess.CalledProcessError as e:\n",
+    "        print(f\"Secret creation  failed. Error: {e}\")\n",
+    "\n",
+    "\n",
+    "s3_access_data = \"spark.hadoop.fs.s3a.access.key EXAMPLE_ACCESS_KEY\"\n",
+    "s3_secret_data = \"spark.hadoop.fs.s3a.secret.key EXAMPLE_SECRET_KEY\"\n",
+    "\n",
+    "s3_data = s3_access_data.replace('EXAMPLE_ACCESS_KEY', os.environ['AUTH_TOKEN'])\n",
+    "s3_data += \"\\n\" + s3_secret_data.replace(\"EXAMPLE_SECRET_KEY\", \"s3\")\n",
+    "\n",
+    "namespace = os.environ['USER']\n",
+    "spark_secret = \"spark-s3-secret\"\n",
+    "\n",
+    "#Save data to a file spark-defaults.conf\n",
+    "with open('spark-defaults.conf', 'w') as file:\n",
+    "    file.write(s3_data)\n",
+    "\n",
+    "\n",
+    "# Call the function to deploy the Kubernetes secret\n",
+    "deploy_s3_secret(namespace, spark_secret)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "authorship_tag": "ABX9TyMUyEIXKPIvKiU5I2T//pwx",
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "MLflow-example-notebook.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
+++ b/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
@@ -12,15 +12,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "outputs": [
-    {
-     "ename": "SyntaxError",
-     "evalue": "invalid syntax (344526381.py, line 26)",
-     "output_type": "error",
-     "traceback": [
-      "\u001B[0;36m  Cell \u001B[0;32mIn[2], line 26\u001B[0;36m\u001B[0m\n\u001B[0;31m    s3_data += \"\\n\" + s3_secret_data.replace(\"EXAMPLE_SECRET_KEY\",  <S3_OBJECT_STORE_SECRET_KEY>)\u001B[0m\n\u001B[0m                                                                    ^\u001B[0m\n\u001B[0;31mSyntaxError\u001B[0m\u001B[0;31m:\u001B[0m invalid syntax\n"
-     ]
+   "execution_count": null,
+   "outputs": []
     }
    ],
    "source": [
@@ -100,3 +93,4 @@
  "nbformat": 4,
  "nbformat_minor": 4
 }
+

--- a/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
+++ b/Data-Analytics/Spark-S3-secret/spark-secret-creation.ipynb
@@ -12,8 +12,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (344526381.py, line 26)",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;36m  Cell \u001B[0;32mIn[2], line 26\u001B[0;36m\u001B[0m\n\u001B[0;31m    s3_data += \"\\n\" + s3_secret_data.replace(\"EXAMPLE_SECRET_KEY\",  <S3_OBJECT_STORE_SECRET_KEY>)\u001B[0m\n\u001B[0m                                                                    ^\u001B[0m\n\u001B[0;31mSyntaxError\u001B[0m\u001B[0;31m:\u001B[0m invalid syntax\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import subprocess\n",
@@ -34,6 +43,14 @@
     "\n",
     "s3_data = s3_access_data.replace('EXAMPLE_ACCESS_KEY', os.environ['AUTH_TOKEN'])\n",
     "s3_data += \"\\n\" + s3_secret_data.replace(\"EXAMPLE_SECRET_KEY\", \"s3\")\n",
+    "\n",
+    "#To connect directly to S3 object, comment the above 2 lines and\n",
+    "#uncomment the following 2 lines.\n",
+    "#Replace the <S3_OBJECT_STORE_ACCESS_KEY> with object store access key\n",
+    "#Replace the <S3_OBJECT_STORE_SECRET_KEY> with object store secret key\n",
+    "\n",
+    "#s3_data = s3_access_data.replace('EXAMPLE_ACCESS_KEY', <S3_OBJECT_STORE_ACCESS_KEY>)\n",
+    "#s3_data += \"\\n\" + s3_secret_data.replace(\"EXAMPLE_SECRET_KEY\",  <S3_OBJECT_STORE_SECRET_KEY>)\n",
     "\n",
     "namespace = os.environ['USER']\n",
     "spark_secret = \"spark-s3-secret\"\n",


### PR DESCRIPTION
- Added new subsection Spark-S3-secret under Data-Analytics/Spark.
- Added an example notebook for creation of spark s3 secret. This secret will be used to connect to the new s3 proxy server to ultimately talk to an object store from spark.

Checklist:

- [x] I have checked that my enhancements are not duplicates of existing content changes or additions.
- [x] I have tested the changes in a working environment to ensure they function as intended.
- [x] I have followed the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      outlined in the contribution guidelines.

Reviewer's Tasks (for maintainers reviewing this PR):

- [ ] Verify that the tutorial functions correctly in a live environment.
- [ ] Verify that the updated content aligns with the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      in the contribution guidelines.
- [ ] Check for consistency, grammar, and clarity throughout the updated content.
- [ ] Check that the related GitHub issue is up-to-date.
