### PR TITLE
Update load_s3_csv_to_mariadb_db_swiss.py

### DIFF
--- a/Data-Engineering/Airflow/load_s3_csv_to_mariadb_db_swiss.py
+++ b/Data-Engineering/Airflow/load_s3_csv_to_mariadb_db_swiss.py
@@ -56,7 +56,7 @@ def read_csv_from_s3(bucket_name, file_name, s3_endpoint, access_key=None, secre
     return df
 
 def import_csv_to_mariadb(df, db_host, db_port, db_user, db_password, db_name, table_name):
-    conn = MySQLdb.connector.connect(
+    conn = MySQLdb.connect(
         host=db_host,
         port=db_port,
         user=db_user,


### PR DESCRIPTION
Adapt Retail Demo DAG

In EZUA 1.1 an other imported package is needed as usual because of Airflow Version. It's MySQLdb which has no connector but a connect function. Let's see if it fixes the issue, if yes will adapt all 3 DAGs
