### PR TITLE
Create a Python virtual environment using the `venv` module for the Ride Sharing tutorial

### DIFF
--- a/tutorials/feast/README.md
+++ b/tutorials/feast/README.md
@@ -24,15 +24,32 @@ To complete the tutorial follow the steps below:
    Notebook server.
 1. Connect to the Notebook server, launch a new terminal window, and clone the repository locally.
 1. Navigate to the tutorial's directory (`ezua-tutorials/tutorials/feast`).
-1. Create a new conda environment using the specified `environment.yaml` file:
-   ```
-   conda env create -f environment.yaml
-   ```
-1. Add the new conda environment as an ipykernel:
-   ```
-   python -m ipykernel install --user --name=ride-sharing
-   ```
-1. Refresh your browser tab to access the updated environment.
+1. Create your virtual environment:
+    - Deactivate the base conda environment:
+        ```
+        conda deactivate
+        ```
+    - Create a new virtual environment:
+       ```
+       python -m venv ride-sharing
+       ```
+    - Activate the new virtual environment:
+       ```
+       source ride-sharing/bin/activate
+       ```
+    - Upgrade `pip`:
+       ```
+       pip install --upgrade pip
+       ```
+    - Install the dependencies:
+       ```
+       pip install -r requirements.txt
+       ```
+    - Add the new conda environment as an ipykernel:
+       ```
+       python -m ipykernel install --user --name=ride-sharing
+       ```
+    - Refresh your browser tab to access the updated environment.
 1. Launch the `ride-sharing.ipynb` Notebook and execute the code cells. Make sure to select the `ride-sharing`
    environment kernel.
 

--- a/tutorials/feast/requirements.txt
+++ b/tutorials/feast/requirements.txt
@@ -1,0 +1,4 @@
+feast==0.34.1
+scikit-learn==1.3.1
+jupyter==1.0.0
+ipywidgets==7.7.5


### PR DESCRIPTION
- Use the Python `venv` module to create a virtual environment instead of conda, as conda is really slow.
- Updated the README file to document the changes.

Checklist:

- [x] I have checked that my enhancements are not duplicates of existing content changes or additions.
- [x] I have tested the changes in a working environment to ensure they function as intended.
- [x] I have followed the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide) outlined in the contribution guidelines.

Reviewer's Tasks (for maintainers reviewing this PR):

- [x] Verify that the tutorial functions correctly in a live environment.
- [x] Verify that the updated content aligns with the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide) in the contribution guidelines.
- [x] Check for consistency, grammar, and clarity throughout the updated content.
- [x] Check that the related GitHub issue is up-to-date.
