### PR TITLE
EZAF-4161: Update kubeflow examples

### DIFF
--- a/Data-Science/Kubeflow/Financial-Time-Series/financial_time_series_example.ipynb
+++ b/Data-Science/Kubeflow/Financial-Time-Series/financial_time_series_example.ipynb
@@ -151,21 +151,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOMEDIR = !echo $HOME\n",
-    "HOMEDIR = HOMEDIR[0]"
+    "# Specify the name of the mounted directory\n",
+    "user_mounted_dir_name = \"user\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "fn = f\"{HOMEDIR}/user/financial-processed\""
+    "from pathlib import Path\n",
+    "fn = f\"{str(Path.home())}/{user_mounted_dir_name}/financial-processed\""
    ]
   },
   {

--- a/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
+++ b/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
@@ -12,6 +12,27 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b4684c50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ######################################### E2E Demo example precondition ##############################################\n",
+    "\n",
+    "# # You need to generate secret to have ability read datasource files from S3 bucket by Spark application (Airflow DAG)\n",
+    "# # Copy template \"object_store_secret.yaml.tpl\" from shared/ezua-tutorials/Data-Analytics/Spark directory to e.g. user folder\n",
+    "\n",
+    "import kfp\n",
+    "\n",
+    "kfp_client = kfp.Client()\n",
+    "namespace = kfp_client.get_user_namespace()\n",
+    "\n",
+    "!sed -e \"s/\\$AUTH_TOKEN/$AUTH_TOKEN/\" /mnt/user/object_store_secret.yaml.tpl > /tmp/object_store_secret.yaml\n",
+    "!kubectl apply -f /tmp/object_store_secret.yaml -n {namespace}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "89bb0c90-a09f-4197-b9a2-f7558efb31de",
    "metadata": {},
    "outputs": [],
@@ -21,6 +42,17 @@
     "# Install required packages (Kubeflow Pipelines and Katib SDK).\n",
     "import sys\n",
     "!{sys.executable} -m pip install \"pyarrow>7.0.0\" \"kfp>=1.8.0,<=1.8.22\" kubeflow-katib==0.16.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0a8f39a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the name of the mounted directory\n",
+    "user_mounted_dir_name = \"user\""
    ]
   },
   {
@@ -52,13 +84,12 @@
     "uuid = uuid.uuid4().hex[:4]\n",
     "\n",
     "# The initial training data is written to the user volume by the spark job in the Apache Parquet format.\n",
-    "initial_training_data_dir = f\"{str(Path.home())}/user/mnist-spark-data\"\n",
+    "initial_training_data_dir = f\"{str(Path.home())}/{user_mounted_dir_name}/mnist-spark-data\"\n",
     "\n",
     "# The path is relative, final_training_data_dir should be in the same folder with the notebook\n",
     "final_training_data_dir=f\"training-{uuid}\"\n",
     "\n",
     "os.mkdir(\"/mnt/user/\" + final_training_data_dir, 0o777)\n",
-    "# os.chmod(\"/mnt/user/\" + final_training_data_dir, 0o777)\n",
     "\n",
     "######################################## KFP parameters ##################################################\n",
     "\n",


### PR DESCRIPTION
Provide a clear and concise description of the content changes you're proposing. List all the changes you are making
to the content.

- Added a cell for user to specify the name of the mounted directory.
- Added back the Spark secret creation step in MNIST example. 

Closes [EZAF-4161](https://jira-pro.it.hpe.com:8443/browse/EZAF-4161)

> If there is no issue related to this PR, kindly create one first to describe the motivation behind these changes.

Checklist:

- [ ] I have checked that my enhancements are not duplicates of existing content changes or additions.
- [ ] I have tested the changes in a working environment to ensure they function as intended.
- [ ] I have followed the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      outlined in the contribution guidelines.

Reviewer's Tasks (for maintainers reviewing this PR):

- [ ] Verify that the tutorial functions correctly in a live environment.
- [ ] Verify that the updated content aligns with the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      in the contribution guidelines.
- [ ] Check for consistency, grammar, and clarity throughout the updated content.
- [ ] Check that the related GitHub issue is up-to-date.
