### PR TITLE
Update path for ezua-tutorials: add symlink to current release version

### DIFF
--- a/Data-Analytics/Spark-GPU/Python/scala-gpu-example.yaml
+++ b/Data-Analytics/Spark-GPU/Python/scala-gpu-example.yaml
@@ -22,7 +22,7 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-gpu-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark-GPU/Python/SqlOnGpuExample.py"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark-GPU/Python/SqlOnGpuExample.py"
   restartPolicy:
     type: Never
   imagePullSecrets:

--- a/Data-Analytics/Spark-GPU/Scala/scala-gpu-example.yaml
+++ b/Data-Analytics/Spark-GPU/Scala/scala-gpu-example.yaml
@@ -22,7 +22,7 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-gpu-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark-GPU/Scala/SparkExamples.jar"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark-GPU/Scala/SparkExamples.jar"
   mainClass: com.hpe.examples.spark.sql.SqlOnGpuExample
   restartPolicy:
     type: Never

--- a/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransferFts.yaml
+++ b/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransferFts.yaml
@@ -15,7 +15,7 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar"
   mainClass: com.mapr.sparkdemo.DataProcessTransfer
   arguments:
     - s3a://ezua-demo/data/financial.csv               # source path

--- a/Data-Analytics/Spark/DataTransfer/DataTransferMnist.yaml
+++ b/Data-Analytics/Spark/DataTransfer/DataTransferMnist.yaml
@@ -15,7 +15,7 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark/DataTransfer/DataTransfer.jar"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar"
   mainClass: com.mapr.sparkdemo.DataTransfer
   arguments:
     - s3a://ezua-demo/data/mnist

--- a/Data-Analytics/Spark/pi/pi.yaml
+++ b/Data-Analytics/Spark/pi/pi.yaml
@@ -9,7 +9,7 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark/pi/pi.py"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/pi/pi.py"
   restartPolicy:
     type: Never
   imagePullSecrets:

--- a/Data-Analytics/Spark/wordcount/wordcount.yaml
+++ b/Data-Analytics/Spark/wordcount/wordcount.yaml
@@ -9,9 +9,9 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark/wordcount/wordcount.py"
+  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.py"
   arguments:
-  - file:///mounts/shared-volume/ezua-tutorials/Data-Analytics/Spark/wordcount/wordcount.txt
+  - file:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.txt
   restartPolicy:
     type: Never
   imagePullSecrets:

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -17,7 +17,7 @@ spec:
   mode: cluster
   image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.0:v3.5.0'
   imagePullPolicy: Always
-  mainApplicationFile: local:///mnt/shared/ezua-tutorials/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
+  mainApplicationFile: local:///mnt/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer
   arguments:
     - s3a://{{dag_run.conf["s3_bucket"]}}/{{dag_run.conf["s3_path"]}}

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -17,7 +17,7 @@ spec:
   mode: cluster
   image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.0:v3.5.0'
   imagePullPolicy: Always
-  mainApplicationFile: local:///mnt/shared/ezua-tutorials/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
+  mainApplicationFile: local:///mnt/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer
   arguments:
     - s3a://{{dag_run.conf["s3_bucket"]}}/{{dag_run.conf["s3_path"]}}

--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -11,7 +11,7 @@ spec:
   imagePullSecrets:
   - imagepull
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///mnt/shared/ezua-tutorials/Data-Analytics/Spark/pi/pi.py"
+  mainApplicationFile: "local:///mnt/shared/ezua-tutorials/current-release/Data-Analytics/Spark/pi/pi.py"
   restartPolicy:
     type: Never
   driver:

--- a/Data-Science/Kubeflow-GPU/Train_and_infer_mnist.ipynb
+++ b/Data-Science/Kubeflow-GPU/Train_and_infer_mnist.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "def mnist_datasets():\n",
-    "    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data(path='/mnt/shared/ezua-tutorials/Data-Science/Kubeflow-GPU/mnist.npz')\n",
+    "    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data(path='/mnt/shared/ezua-tutorials/current-release/Data-Science/Kubeflow-GPU/mnist.npz')\n",
     "    x_train, x_test = x_train / np.float32(255), x_test / np.float32(255)\n",
     "    y_train, y_test = y_train.astype(np.int64), y_test.astype(np.int64)\n",
     "    return x_train, x_test, y_train, y_test"
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "# Set current JWT token as access and secret key for local minio\n",
-    "!sed -e \"s/\\$AUTH_TOKEN/$AUTH_TOKEN/\" /mnt/shared/ezua-tutorials/Data-Science/Kubeflow-GPU/object_store_sa_secret.yaml.tpl > /tmp/object_store_sa_secret.yaml"
+    "!sed -e \"s/\\$AUTH_TOKEN/$AUTH_TOKEN/\" /mnt/shared/ezua-tutorials/current-release/Data-Science/Kubeflow-GPU/object_store_sa_secret.yaml.tpl > /tmp/object_store_sa_secret.yaml"
    ]
   },
   {
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "# Create inferenceservice for trained mnist model\n",
-    "with open('/mnt/shared/ezua-tutorials/Data-Science/Kubeflow-GPU/gpu_mnist_inferenceservice.yaml', 'r') as file:\n",
+    "with open('/mnt/shared/ezua-tutorials/current-release/Data-Science/Kubeflow-GPU/gpu_mnist_inferenceservice.yaml', 'r') as file:\n",
     "    inferenceservice_yaml_data = yaml.safe_load(file)\n",
     "\n",
     "inferenceservice_yaml_data[\"spec\"][\"predictor\"][\"tensorflow\"][\"storageUri\"] = saved_model_path\n",

--- a/Data-Science/Kubeflow-GPU/Train_mnist_kfp_gpu.ipynb
+++ b/Data-Science/Kubeflow-GPU/Train_mnist_kfp_gpu.ipynb
@@ -45,7 +45,7 @@
    "outputs": [],
    "source": [
     "def mnist_datasets():\n",
-    "    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data(path='/mnt/shared/ezua-tutorials/Data-Science/Kubeflow-GPU/mnist.npz')\n",
+    "    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data(path='/mnt/shared/ezua-tutorials/current-release/Data-Science/Kubeflow-GPU/mnist.npz')\n",
     "    x_train, x_test = x_train / np.float32(255), x_test / np.float32(255)\n",
     "    y_train, y_test = y_train.astype(np.int64), y_test.astype(np.int64)\n",
     "    return x_train, x_test, y_train, y_test"

--- a/Data-Science/Kubeflow/Financial-Time-Series/financial_time_series_example.ipynb
+++ b/Data-Science/Kubeflow/Financial-Time-Series/financial_time_series_example.ipynb
@@ -74,7 +74,7 @@
     "######################################### E2E Demo example precondition ##############################################\n",
     "\n",
     "# You need to generate secret to have ability read datasource files from S3 bucket by Spark application (Airflow DAG)\n",
-    "# Copy template \"object_store_secret.yaml.tpl\" from shared/ezua-tutorials/Data-Analytics/Spark directory to e.g. user folder\n",
+    "# Copy template \"object_store_secret.yaml.tpl\" from shared/ezua-tutorials/current-release/Data-Analytics/Spark directory to e.g. user folder\n",
     "\n",
     "import kfp\n",
     "\n",

--- a/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
+++ b/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
@@ -19,7 +19,7 @@
     "# ######################################### E2E Demo example precondition ##############################################\n",
     "\n",
     "# # You need to generate secret to have ability read datasource files from S3 bucket by Spark application (Airflow DAG)\n",
-    "# # Copy template \"object_store_secret.yaml.tpl\" from shared/ezua-tutorials/Data-Analytics/Spark directory to e.g. user folder\n",
+    "# # Copy template \"object_store_secret.yaml.tpl\" from shared/ezua-tutorials/current-release/Data-Analytics/Spark directory to e.g. user folder\n",
     "\n",
     "import kfp\n",
     "\n",


### PR DESCRIPTION
Fix paths which are referring ezua-tutorials folder from the shared volume. Use symlink `current-release` instead of hardcoding specific release version