### PR TITLE
demos/qna: Fix short-lived token bug

### DIFF
--- a/demos/rag-demos/question-answering/dockerfiles/transformer/src/model.py
+++ b/demos/rag-demos/question-answering/dockerfiles/transformer/src/model.py
@@ -44,10 +44,9 @@ class Transformer(Model):
 
     @property
     def _http_client(self):
-        if self._http_client_instance is None:
-            headers = {"Authorization": self.authorization}
-            self._http_client_instance = httpx.AsyncClient(headers=headers,
-                                                           verify=False)
+        headers = {"Authorization": self.authorization}
+        self._http_client_instance = httpx.AsyncClient(
+            headers=headers, verify=False)
         return self._http_client_instance
 
     def preprocess(self, request: dict, headers: dict) -> dict:


### PR DESCRIPTION
EzUA uses a short-lived authentication token, instead of the long-lived one used in EzUA `1.2.0`.

Refresh the authentication token with every request in the QnA transformer component.

Checklist:

- [x] I have checked that my enhancements are not duplicates of existing content changes or additions.
- [x] I have tested the changes in a working environment to ensure they function as intended.
- [x] I have followed the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide) outlined in the contribution guidelines.

Reviewer's Tasks (for maintainers reviewing this PR):

- [x] Verify that the tutorial functions correctly in a live environment.
- [x] Verify that the updated content aligns with the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide) in the contribution guidelines.
- [x] Check for consistency, grammar, and clarity throughout the updated content.
- [x] Check that the related GitHub issue is up-to-date.
