### PR TITLE
EZESC-1933 -Update wordcount.yaml to remove duplicate volume

### DIFF
--- a/Data-Analytics/Spark/wordcount/wordcount.yaml
+++ b/Data-Analytics/Spark/wordcount/wordcount.yaml
@@ -9,9 +9,9 @@ spec:
   mode: cluster
   image: gcr.io/mapr-252711/spark-3.5.0:v3.5.0
   imagePullPolicy: Always
-  mainApplicationFile: "local:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.py"
+  mainApplicationFile: "local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.py"
   arguments:
-  - file:///mounts/shared-volume/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.txt
+  - file:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/wordcount/wordcount.txt
   restartPolicy:
     type: Never
   imagePullSecrets:
@@ -19,16 +19,6 @@ spec:
   driver:
     labels:
       version: 3.5.0
-    volumeMounts:
-      - name: shared-volume
-        mountPath: /mounts/shared-volume
   executor:
     labels:
       version: 3.5.0
-    volumeMounts:
-      - name: shared-volume
-        mountPath: /mounts/shared-volume
-  volumes:
-    - name: shared-volume
-      persistentVolumeClaim:
-        claimName: kubeflow-shared-pvc


### PR DESCRIPTION
The original example from release/fy24-q2 doesn't work because 'shared-volume' can't mount kubeflow-shared-pv, because the Spark Operator pods already have a volume called 'pv1' mounted to that same PVC. To get the example to work, we have to remove all references to the shared-volume volume and volume mount, and then update mainApplicationFile and 'arguments' to get the necessary data from its location on the 'pv1' mount.

Provide a clear and concise description of the content changes you're proposing. List all the changes you are making
to the content.

- Updated section ___ with ___.
- Added new subsection ___ under ___.
- Removed outdated information from ___.
- ...

Closes #...

> If there is no issue related to this PR, kindly create one first to describe the motivation behind these changes.

Checklist:

- [ ] I have checked that my enhancements are not duplicates of existing content changes or additions.
- [ ] I have tested the changes in a working environment to ensure they function as intended.
- [ ] I have followed the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      outlined in the contribution guidelines.

Reviewer's Tasks (for maintainers reviewing this PR):

- [ ] Verify that the tutorial functions correctly in a live environment.
- [ ] Verify that the updated content aligns with the [style guide](https://github.com/HPEEzmeral/ezua-tutorials/blob/develop/CONTRIBUTING.md#style-guide)
      in the contribution guidelines.
- [ ] Check for consistency, grammar, and clarity throughout the updated content.
- [ ] Check that the related GitHub issue is up-to-date.
