### PR TITLE
Add note on deleting user 

### DIFF
--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -4,9 +4,9 @@ metadata:
   name: spark-pi-oss-{{ts_nodash|replace("T", "")}}
 spec:
   type: Python
-  sparkVersion: '{{dag_run.conf["spark_image_version"]}}'
+  sparkVersion: '{{dag_run.conf["Spark-image-version"]}}'
   mode: cluster
-  image: '{{dag_run.conf["spark_image_url"]|default("", True)}}'
+  image: '{{dag_run.conf["Spark-image"]|default("", True)}}'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull
@@ -19,11 +19,11 @@ spec:
     coreLimit: "1000m"
     memory: "512m"
     labels:
-      version: '{{dag_run.conf["spark_image_version"]}}'
+      version: '{{dag_run.conf["Spark-image-version"]}}'
   executor:
     cores: 1
     instances: 2
     coreLimit: "1000m"
     memory: "512m"
     labels:
-      version: '{{dag_run.conf["spark_image_version"]}}'
+      version: '{{dag_run.conf["Spark-image-version"]}}'

--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -932,6 +932,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Before proceeding with the deletion of your user account, please ensure that all privileges in MLflow are explicitly deleted to avoid any potential data loss or workflow disruption."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/Model-Monitoring/Spark/Data_Validation_Spark.ipynb
+++ b/Model-Monitoring/Spark/Data_Validation_Spark.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "- Select Add Endpoint\n",
     "- Select Single Sign-On\n",
-    "- Select Create Session, selecting language as Python and in properties use \"spark.kubernetes.container.image\": \"gcr.io/mapr-252711/spark-3.5.0:202401221805R\" the whylogs -integerated spark image in properties.\n",
+    "- Select Create Session, selecting language as Python and in properties use \"spark.kubernetes.container.image\": \"gcr.io/mapr-252711/spark-3.5.0:202405022330R\" the whylogs -integerated spark image in properties.\n",
     "- Click Create Session\n",
     "\n",
     "When your session is ready the Manage Sessions pane will become active, providing you the session ID. The session state will become idle which means that you are good to go!\n",

--- a/Model-Monitoring/Spark/Whylogs_Profiling_Spark.ipynb
+++ b/Model-Monitoring/Spark/Whylogs_Profiling_Spark.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "- Select Add Endpoint\n",
     "- Select Single Sign-On\n",
-    "- Select Create Session, selecting language as Python and in properties use \"spark.kubernetes.container.image\": \"gcr.io/mapr-252711/spark-3.5.0:202401221805R\" the whylogs -integerated spark image in properties.\n",
+    "- Select Create Session, selecting language as Python and in properties use \"spark.kubernetes.container.image\": \"gcr.io/mapr-252711/spark-3.5.0:202405022330R\" the whylogs -integerated spark image in properties.\n",
     "- Click Create Session\n",
     "\n",
     "When your session is ready the Manage Sessions pane will become active, providing you the session ID. The session state will become idle which means that you are good to go!\n",


### PR DESCRIPTION

MLFlow backend does not delete user experiment/model permission objects associated with the user, which is the root cause for user privilege of member persisting even after deleting and re-adding the user.
This behaviour is as expected with the mlflow implementation :
https://github.com/mlflow/mlflow/blob/9cde849e2fa8ab5cf047df09d985930db1c658a4/mlflow/server/auth/__init__.py#L818-L821
Adding a note to explicitly delete all user permissions when deleting the user to address ticket : https://jira-pro.it.hpe.com:8443/browse/EZAF-5000