### PR TITLE
Add note to delete user permissions

### DIFF
--- a/Data-Science/MLflow/bike-sharing-mlflow.ipynb
+++ b/Data-Science/MLflow/bike-sharing-mlflow.ipynb
@@ -932,6 +932,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Before proceeding with the deletion of your user account, please ensure that all privileges in MLflow are explicitly deleted to avoid any potential data loss or workflow disruption."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
MLFlow backend does not delete user experiment/model permission objects associated with the user, which is the root cause for user privilege of member persisting even after deleting and re-adding the user.
This behaviour is as expected with the mlflow implementation :
https://github.com/mlflow/mlflow/blob/9cde849e2fa8ab5cf047df09d985930db1c658a4/mlflow/server/auth/__init__.py#L818-L821
Adding a note to explicitly delete all user permissions when deleting the user to address ticket : https://jira-pro.it.hpe.com:8443/browse/EZAF-5000
