### PR TITLE
Update DAGs for Airflow v2.9.2

### DIFF
--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
@@ -60,18 +60,16 @@ dag = DAG(
 submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_ezaf_spark_csv_to_parquet_fts.yaml",
-    do_xcom_push=True,
+    # do_xcom_push=True,
     dag=dag,
-    api_group="sparkoperator.hpe.com",
     enable_impersonation_from_ldap_user=True,
 )
 
-sensor = SparkKubernetesSensor(
-    task_id="monitor",
-    application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
-    dag=dag,
-    api_group="sparkoperator.hpe.com",
-    attach_log=True,
-)
+# sensor = SparkKubernetesSensor(
+#     task_id="monitor",
+#     application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
+#     dag=dag,
+#     attach_log=True,
+# )
 
-submit >> sensor
+# submit >> sensor

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.py
@@ -61,6 +61,7 @@ submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_ezaf_spark_csv_to_parquet_fts.yaml",
     # do_xcom_push=True,
+    delete_on_termination=False,
     dag=dag,
     enable_impersonation_from_ldap_user=True,
 )

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
@@ -61,6 +61,7 @@ submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_ezaf_spark_mnist.yaml",
     # do_xcom_push=True,
+    delete_on_termination=False,
     dag=dag,
     enable_impersonation_from_ldap_user=True,
 )

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.py
@@ -60,18 +60,16 @@ dag = DAG(
 submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_ezaf_spark_mnist.yaml",
-    do_xcom_push=True,
+    # do_xcom_push=True,
     dag=dag,
-    api_group="sparkoperator.hpe.com",
     enable_impersonation_from_ldap_user=True,
 )
 
-sensor = SparkKubernetesSensor(
-    task_id="monitor",
-    application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
-    dag=dag,
-    api_group="sparkoperator.hpe.com",
-    attach_log=True,
-)
+# sensor = SparkKubernetesSensor(
+#     task_id="monitor",
+#     application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
+#     dag=dag,
+#     attach_log=True,
+# )
 
-submit >> sensor
+# submit >> sensor

--- a/Data-Engineering/Airflow/example_spark_pi.py
+++ b/Data-Engineering/Airflow/example_spark_pi.py
@@ -39,18 +39,16 @@ dag = DAG(
 submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_spark_pi.yaml",
-    do_xcom_push=True,
+    # do_xcom_push=True,
     dag=dag,
-    api_group="sparkoperator.hpe.com",
     enable_impersonation_from_ldap_user=True,
 )
 
-sensor = SparkKubernetesSensor(
-    task_id="monitor",
-    application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
-    dag=dag,
-    api_group="sparkoperator.hpe.com",
-    attach_log=True,
-)
+# sensor = SparkKubernetesSensor(
+#     task_id="monitor",
+#     application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
+#     dag=dag,
+#     attach_log=True,
+# )
 
-submit >> sensor
+# submit >> sensor

--- a/Data-Engineering/Airflow/example_spark_pi.py
+++ b/Data-Engineering/Airflow/example_spark_pi.py
@@ -40,6 +40,7 @@ submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_spark_pi.yaml",
     # do_xcom_push=True,
+    delete_on_termination=False,
     dag=dag,
     enable_impersonation_from_ldap_user=True,
 )

--- a/Data-Engineering/Airflow/example_spark_pi_oss.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi_oss.yaml
@@ -4,9 +4,9 @@ metadata:
   name: spark-pi-oss-{{ts_nodash|replace("T", "")}}
 spec:
   type: Python
-  sparkVersion: '{{dag_run.conf["Spark-image-version"]}}'
+  sparkVersion: '{{dag_run.conf["spark_image_version"]}}'
   mode: cluster
-  image: '{{dag_run.conf["Spark-image"]|default("", True)}}'
+  image: '{{dag_run.conf["spark_image_url"]|default("", True)}}'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull
@@ -19,11 +19,11 @@ spec:
     coreLimit: "1000m"
     memory: "512m"
     labels:
-      version: '{{dag_run.conf["Spark-image-version"]}}'
+      version: '{{dag_run.conf["spark_image_version"]}}'
   executor:
     cores: 1
     instances: 2
     coreLimit: "1000m"
     memory: "512m"
     labels:
-      version: '{{dag_run.conf["Spark-image-version"]}}'
+      version: '{{dag_run.conf["spark_image_version"]}}'

--- a/Data-Engineering/Airflow/exmample_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/exmample_spark_pi_oss.py
@@ -44,6 +44,7 @@ submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_spark_pi_oss.yaml",
     # do_xcom_push=True,
+    delete_on_termination=False,
     dag=dag,
     enable_impersonation_from_ldap_user=True,
 )

--- a/Data-Engineering/Airflow/exmample_spark_pi_oss.py
+++ b/Data-Engineering/Airflow/exmample_spark_pi_oss.py
@@ -43,18 +43,16 @@ dag = DAG(
 submit = SparkKubernetesOperator(
     task_id="submit",
     application_file="example_spark_pi_oss.yaml",
-    do_xcom_push=True,
+    # do_xcom_push=True,
     dag=dag,
-    api_group="sparkoperator.hpe.com",
     enable_impersonation_from_ldap_user=True,
 )
 
-sensor = SparkKubernetesSensor(
-    task_id="monitor",
-    application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
-    dag=dag,
-    api_group="sparkoperator.hpe.com",
-    attach_log=True,
-)
+# sensor = SparkKubernetesSensor(
+#     task_id="monitor",
+#     application_name="{{ task_instance.xcom_pull(task_ids='submit')['metadata']['name'] }}",
+#     dag=dag,
+#     attach_log=True,
+# )
 
-submit >> sensor
+# submit >> sensor


### PR DESCRIPTION
Updated DAGs for new version of Airflow 2.9.2. We don't need a sensor, because submit can now monitor logs and status, so we can also remove xcom. API group argument was removed from the constructor of the class in OSS cncf provider