### PR TITLE
EZAF-7138: [Whylogs]: Issue in Whylogs Ray example, job gets completed successfully but ends with errors in notebook

### DIFF
--- a/Model-Monitoring/RAY/mandlebrot.py
+++ b/Model-Monitoring/RAY/mandlebrot.py
@@ -1,6 +1,6 @@
 import piexif
 import random
-import ray 
+import ray
 import ipyplot
 import ray.data as df
 from PIL import Image
@@ -19,97 +19,77 @@ from whylogs.extras.image_metric import ImageMetric, ImageMetricConfig
 
 class ImageResolver(StandardResolver):
     def resolve(self, name: str, why_type: DataType, column_schema: ColumnSchema) -> Dict[str, Metric]:
-        print(name)
-        print(why_type)
-        print(column_schema)
-        
         if "image" in name:
             return {ImageMetric.get_namespace(): ImageMetric.zero(column_schema.cfg)}
-        return super(ImageResolver, self).resolve(name, why_type, column_schema)
+        return super().resolve(name, why_type, column_schema)
 
 class RayWhylogsImgBinProfileExpActor():
-    
+
     def __init__(self):
         self.img1 = Image.effect_mandelbrot((256, 256), (-3, -2.5, 2, 2.5), 9)
         self.img2 = Image.effect_mandelbrot((256, 256), (-3, -2.5, 2, 2.5), 20)
         self._result = {}
         self._fractal_images = []
         self._cnt = 100
-    
-    '''
-     @ description: 
-     # The assuming that `generate_mandelbrot()` function provides a series of mandelbrot fractal image and structures for image analysis and processing experiment purpose.
-    '''
+
     def generate_mandelbrot(self, width, height, x_min, y_min, x_max, y_max, iterations):
         try:
-            for item in range(0, self._cnt):
-                self._fractal_images.append(Image.effect_mandelbrot((width, height), 
-                                                                    (-int(random.randint(1.0,5.0)), 
-                                                                     -int(random.randint(1.0,5.0)), 
-                                                                     random.randint(1.0,5.0), 
-                                                                     random.randint(1.0,5.0)), iterations))
+            for _ in range(self._cnt):
+                img = Image.effect_mandelbrot(
+                    (width, height),
+                    (-random.randint(1, 5), -random.randint(1, 5), random.randint(1, 5), random.randint(1, 5)),
+                    iterations
+                )
+                if img is not None:  # Check if img is valid
+                    self._fractal_images.append(img)
             return self._fractal_images
         except Exception as error:
             print(traceback.format_exc())
-        
-    '''
-     @ description: 
-     # The `log_image()` function provides a simple interface for logging images.
-    '''
+
     def get_binary_data(self):
         try:
             display(self.img1)
             display(self.img2)
             results = log_image(self.img1)
-            print("=*="*50)
-            print(results.view().get_column("image").to_summary_dict())
-            return self.img1,self.img2
+            print("Results Summary:", results.view().get_column("image").to_summary_dict())
+            return self.img1, self.img2
         except Exception as error:
-            print("Exception: get_binary_data", traceback.format_exc())
-    
-    '''
-     @ description: 
-     # On top of this remote actor function you can see, here just passing in an `Image` results in a column named "image" in the profile. 
-     # You can pass in a list of images, which will append an index to each column name:
-    '''
+            print("Exception in get_binary_data:", traceback.format_exc())
+
     def get_logged_column_dtls(self, lstmandelbrot: list):
         try:
-            print("=*="*50)
-            
+            if len(lstmandelbrot) == 0:
+                print("No images to log.")
+                return None
+            elif len(lstmandelbrot) <= 99:
+                print("Not enough images to access the 100th image.")
+                return None
+
             self._result = log_image(list(lstmandelbrot))
             schema = DatasetSchema(resolvers=ImageResolver(), default_configs=ImageMetricConfig())
             stats = Stat(lstmandelbrot[99])
             df = pd.DataFrame({"median": stats.median, "sum": stats.sum, "images": lstmandelbrot[99]})
             results = why.log(df, schema=schema).view()
-            
-            print("whyloged image columns::", results.get_column("median").to_summary_dict())
-            print("whyloged image columns::", results.get_column("sum").to_summary_dict())
-            print("whyloged image columns::", results.get_column("images").to_summary_dict())
-            #print("whyloged image columns::", list(results.view().get_columns()))
-            #print("whyloged image columns::", results.view().get_column("image_1").to_summary_dict())
-            
-            print("=*="*50)
-            
+
+            print("Logged image columns summary:", results.get_column("median").to_summary_dict())
+            print("Logged image columns sum:", results.get_column("sum").to_summary_dict())
+            print("Logged image columns images:", results.get_column("images").to_summary_dict())
+
             return self._result
         except Exception as error:
-            print(traceback.format_exc())
+            print("Exception in get_logged_column_dtls:", traceback.format_exc())
 
 def main_exp():
     try:
-        # Create an instance of the RayWhylogsImgBinProfileExpActor
         objraywhylogsprf = RayWhylogsImgBinProfileExpActor()
+        lstmandelbrot = objraywhylogsprf.generate_mandelbrot(256, 256, -2.0, -1.5, 1.0, 1.5, 100)
+        print("Generated number of images:", len(lstmandelbrot))
 
-        # Generate Mandelbrot images
-        lstmandelbrot = objraywhylogsprf.generate_mandelbrot(256, 256, -2.0, -1.5, 1.0, 1.5,100)
-        print("generated no.of images: =========", len(lstmandelbrot))
-        ipyplot.plot_images(lstmandelbrot, max_images=100, img_width=75)
-        
         objraywhylogsprf.get_logged_column_dtls(lstmandelbrot)
         return lstmandelbrot
-        
-    except Exception as error:
-        print(traceback.format_exc())
 
-if __name__=="__main__":
+    except Exception as error:
+        print("Exception in main_exp:", traceback.format_exc())
+
+if __name__ == "__main__":
     main_exp()
-    

--- a/Model-Monitoring/RAY/run.ipynb
+++ b/Model-Monitoring/RAY/run.ipynb
@@ -2,57 +2,110 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
     "import ray\n",
     "from ray.job_submission import JobSubmissionClient\n",
     "import time\n",
-    "from ray.runtime_env import RuntimeEnv\n",
-    "\n",
+    "from ray.runtime_env import RuntimeEnv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Ray cluster information\n",
     "ray_head_ip = \"kuberay-head-svc.kuberay.svc.cluster.local\"\n",
     "ray_head_port = 8265\n",
-    "ray_address = f\"http://{ray_head_ip}:{ray_head_port}\"\n",
-    "\n",
+    "ray_address = f\"http://{ray_head_ip}:{ray_head_port}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-23 16:16:57,137\tINFO dashboard_sdk.py:338 -- Uploading package gcs://_ray_pkg_8c7d245da70f9edd.zip.\n",
+      "2024-10-23 16:16:57,138\tINFO packaging.py:530 -- Creating a file package for local directory './'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ray job submitted with job_id: raysubmit_4Zth1AthLJzKjdAW\n",
+      "Generated number of images: 100\n",
+      "Logged image columns summary: {'counts/n': 1, 'counts/null': 0, 'counts/nan': 0, 'counts/inf': 0, 'counts/true': 0, 'types/integral': 1, 'types/fractional': 0, 'types/boolean': 0, 'types/string': 0, 'types/object': 0, 'types/tensor': 0, 'distribution/mean': 7.0, 'distribution/stddev': 0.0, 'distribution/n': 1, 'distribution/max': 7.0, 'distribution/min': 7.0, 'distribution/q_01': 7.0, 'distribution/q_05': 7.0, 'distribution/q_10': 7.0, 'distribution/q_25': 7.0, 'distribution/median': 7.0, 'distribution/q_75': 7.0, 'distribution/q_90': 7.0, 'distribution/q_95': 7.0, 'distribution/q_99': 7.0, 'ints/max': 7, 'ints/min': 7, 'cardinality/est': 1.0, 'cardinality/upper_1': 1.000049929250618, 'cardinality/lower_1': 1.0, 'frequent_items/frequent_strings': [FrequentItem(value='7', est=1, upper=1, lower=1)]}\n",
+      "Logged image columns sum: {'counts/n': 1, 'counts/null': 0, 'counts/nan': 0, 'counts/inf': 0, 'counts/true': 0, 'types/integral': 0, 'types/fractional': 1, 'types/boolean': 0, 'types/string': 0, 'types/object': 0, 'types/tensor': 0, 'cardinality/est': 1.0, 'cardinality/upper_1': 1.000049929250618, 'cardinality/lower_1': 1.0, 'distribution/mean': 614278.0, 'distribution/stddev': 0.0, 'distribution/n': 1, 'distribution/max': 614278.0, 'distribution/min': 614278.0, 'distribution/q_01': 614278.0, 'distribution/q_05': 614278.0, 'distribution/q_10': 614278.0, 'distribution/q_25': 614278.0, 'distribution/median': 614278.0, 'distribution/q_75': 614278.0, 'distribution/q_90': 614278.0, 'distribution/q_95': 614278.0, 'distribution/q_99': 614278.0}\n",
+      "Logged image columns images: {'image/ImagePixelWidth:counts/n': 1, 'image/ImagePixelWidth:counts/null': 0, 'image/ImagePixelWidth:counts/nan': 0, 'image/ImagePixelWidth:counts/inf': 0, 'image/ImagePixelWidth:counts/true': 0, 'image/ImagePixelWidth:types/integral': 1, 'image/ImagePixelWidth:types/fractional': 0, 'image/ImagePixelWidth:types/boolean': 0, 'image/ImagePixelWidth:types/string': 0, 'image/ImagePixelWidth:types/object': 0, 'image/ImagePixelWidth:types/tensor': 0, 'image/ImagePixelWidth:cardinality/est': 1.0, 'image/ImagePixelWidth:cardinality/upper_1': 1.000049929250618, 'image/ImagePixelWidth:cardinality/lower_1': 1.0, 'image/ImagePixelWidth:distribution/mean': 256.0, 'image/ImagePixelWidth:distribution/stddev': 0.0, 'image/ImagePixelWidth:distribution/n': 1, 'image/ImagePixelWidth:distribution/max': 256.0, 'image/ImagePixelWidth:distribution/min': 256.0, 'image/ImagePixelWidth:distribution/q_01': 256.0, 'image/ImagePixelWidth:distribution/q_05': 256.0, 'image/ImagePixelWidth:distribution/q_10': 256.0, 'image/ImagePixelWidth:distribution/q_25': 256.0, 'image/ImagePixelWidth:distribution/median': 256.0, 'image/ImagePixelWidth:distribution/q_75': 256.0, 'image/ImagePixelWidth:distribution/q_90': 256.0, 'image/ImagePixelWidth:distribution/q_95': 256.0, 'image/ImagePixelWidth:distribution/q_99': 256.0, 'image/ImagePixelWidth:ints/max': 256, 'image/ImagePixelWidth:ints/min': 256, 'image/ImagePixelWidth:frequent_items/frequent_strings': [FrequentItem(value='256', est=1, upper=1, lower=1)], 'image/ImagePixelHeight:counts/n': 1, 'image/ImagePixelHeight:counts/null': 0, 'image/ImagePixelHeight:counts/nan': 0, 'image/ImagePixelHeight:counts/inf': 0, 'image/ImagePixelHeight:counts/true': 0, 'image/ImagePixelHeight:types/integral': 1, 'image/ImagePixelHeight:types/fractional': 0, 'image/ImagePixelHeight:types/boolean': 0, 'image/ImagePixelHeight:types/string': 0, 'image/ImagePixelHeight:types/object': 0, 'image/ImagePixelHeight:types/tensor': 0, 'image/ImagePixelHeight:cardinality/est': 1.0, 'image/ImagePixelHeight:cardinality/upper_1': 1.000049929250618, 'image/ImagePixelHeight:cardinality/lower_1': 1.0, 'image/ImagePixelHeight:distribution/mean': 256.0, 'image/ImagePixelHeight:distribution/stddev': 0.0, 'image/ImagePixelHeight:distribution/n': 1, 'image/ImagePixelHeight:distribution/max': 256.0, 'image/ImagePixelHeight:distribution/min': 256.0, 'image/ImagePixelHeight:distribution/q_01': 256.0, 'image/ImagePixelHeight:distribution/q_05': 256.0, 'image/ImagePixelHeight:distribution/q_10': 256.0, 'image/ImagePixelHeight:distribution/q_25': 256.0, 'image/ImagePixelHeight:distribution/median': 256.0, 'image/ImagePixelHeight:distribution/q_75': 256.0, 'image/ImagePixelHeight:distribution/q_90': 256.0, 'image/ImagePixelHeight:distribution/q_95': 256.0, 'image/ImagePixelHeight:distribution/q_99': 256.0, 'image/ImagePixelHeight:ints/max': 256, 'image/ImagePixelHeight:ints/min': 256, 'image/ImagePixelHeight:frequent_items/frequent_strings': [FrequentItem(value='256', est=1, upper=1, lower=1)], 'image/Colorspace:counts/n': 1, 'image/Colorspace:counts/null': 0, 'image/Colorspace:counts/nan': 0, 'image/Colorspace:counts/inf': 0, 'image/Colorspace:counts/true': 0, 'image/Colorspace:types/integral': 0, 'image/Colorspace:types/fractional': 0, 'image/Colorspace:types/boolean': 0, 'image/Colorspace:types/string': 1, 'image/Colorspace:types/object': 0, 'image/Colorspace:types/tensor': 0, 'image/Colorspace:cardinality/est': 1.0, 'image/Colorspace:cardinality/upper_1': 1.000049929250618, 'image/Colorspace:cardinality/lower_1': 1.0, 'image/Colorspace:frequent_items/frequent_strings': [FrequentItem(value='L', est=1, upper=1, lower=1)], 'image/entropy:counts/n': 1, 'image/entropy:counts/null': 0, 'image/entropy:counts/nan': 0, 'image/entropy:counts/inf': 0, 'image/entropy:counts/true': 0, 'image/entropy:types/integral': 0, 'image/entropy:types/fractional': 1, 'image/entropy:types/boolean': 0, 'image/entropy:types/string': 0, 'image/entropy:types/object': 0, 'image/entropy:types/tensor': 0, 'image/entropy:cardinality/est': 1.0, 'image/entropy:cardinality/upper_1': 1.000049929250618, 'image/entropy:cardinality/lower_1': 1.0, 'image/entropy:distribution/mean': 2.8911258037424057, 'image/entropy:distribution/stddev': 0.0, 'image/entropy:distribution/n': 1, 'image/entropy:distribution/max': 2.8911258037424057, 'image/entropy:distribution/min': 2.8911258037424057, 'image/entropy:distribution/q_01': 2.8911258037424057, 'image/entropy:distribution/q_05': 2.8911258037424057, 'image/entropy:distribution/q_10': 2.8911258037424057, 'image/entropy:distribution/q_25': 2.8911258037424057, 'image/entropy:distribution/median': 2.8911258037424057, 'image/entropy:distribution/q_75': 2.8911258037424057, 'image/entropy:distribution/q_90': 2.8911258037424057, 'image/entropy:distribution/q_95': 2.8911258037424057, 'image/entropy:distribution/q_99': 2.8911258037424057, 'image/Hue.mean:counts/n': 1, 'image/Hue.mean:counts/null': 0, 'image/Hue.mean:counts/nan': 0, 'image/Hue.mean:counts/inf': 0, 'image/Hue.mean:counts/true': 0, 'image/Hue.mean:types/integral': 0, 'image/Hue.mean:types/fractional': 1, 'image/Hue.mean:types/boolean': 0, 'image/Hue.mean:types/string': 0, 'image/Hue.mean:types/object': 0, 'image/Hue.mean:types/tensor': 0, 'image/Hue.mean:cardinality/est': 1.0, 'image/Hue.mean:cardinality/upper_1': 1.000049929250618, 'image/Hue.mean:cardinality/lower_1': 1.0, 'image/Hue.mean:distribution/mean': 0.0, 'image/Hue.mean:distribution/stddev': 0.0, 'image/Hue.mean:distribution/n': 1, 'image/Hue.mean:distribution/max': 0.0, 'image/Hue.mean:distribution/min': 0.0, 'image/Hue.mean:distribution/q_01': 0.0, 'image/Hue.mean:distribution/q_05': 0.0, 'image/Hue.mean:distribution/q_10': 0.0, 'image/Hue.mean:distribution/q_25': 0.0, 'image/Hue.mean:distribution/median': 0.0, 'image/Hue.mean:distribution/q_75': 0.0, 'image/Hue.mean:distribution/q_90': 0.0, 'image/Hue.mean:distribution/q_95': 0.0, 'image/Hue.mean:distribution/q_99': 0.0, 'image/Hue.stddev:counts/n': 1, 'image/Hue.stddev:counts/null': 0, 'image/Hue.stddev:counts/nan': 0, 'image/Hue.stddev:counts/inf': 0, 'image/Hue.stddev:counts/true': 0, 'image/Hue.stddev:types/integral': 0, 'image/Hue.stddev:types/fractional': 1, 'image/Hue.stddev:types/boolean': 0, 'image/Hue.stddev:types/string': 0, 'image/Hue.stddev:types/object': 0, 'image/Hue.stddev:types/tensor': 0, 'image/Hue.stddev:cardinality/est': 1.0, 'image/Hue.stddev:cardinality/upper_1': 1.000049929250618, 'image/Hue.stddev:cardinality/lower_1': 1.0, 'image/Hue.stddev:distribution/mean': 0.0, 'image/Hue.stddev:distribution/stddev': 0.0, 'image/Hue.stddev:distribution/n': 1, 'image/Hue.stddev:distribution/max': 0.0, 'image/Hue.stddev:distribution/min': 0.0, 'image/Hue.stddev:distribution/q_01': 0.0, 'image/Hue.stddev:distribution/q_05': 0.0, 'image/Hue.stddev:distribution/q_10': 0.0, 'image/Hue.stddev:distribution/q_25': 0.0, 'image/Hue.stddev:distribution/median': 0.0, 'image/Hue.stddev:distribution/q_75': 0.0, 'image/Hue.stddev:distribution/q_90': 0.0, 'image/Hue.stddev:distribution/q_95': 0.0, 'image/Hue.stddev:distribution/q_99': 0.0, 'image/Saturation.mean:counts/n': 1, 'image/Saturation.mean:counts/null': 0, 'image/Saturation.mean:counts/nan': 0, 'image/Saturation.mean:counts/inf': 0, 'image/Saturation.mean:counts/true': 0, 'image/Saturation.mean:types/integral': 0, 'image/Saturation.mean:types/fractional': 1, 'image/Saturation.mean:types/boolean': 0, 'image/Saturation.mean:types/string': 0, 'image/Saturation.mean:types/object': 0, 'image/Saturation.mean:types/tensor': 0, 'image/Saturation.mean:cardinality/est': 1.0, 'image/Saturation.mean:cardinality/upper_1': 1.000049929250618, 'image/Saturation.mean:cardinality/lower_1': 1.0, 'image/Saturation.mean:distribution/mean': 0.0, 'image/Saturation.mean:distribution/stddev': 0.0, 'image/Saturation.mean:distribution/n': 1, 'image/Saturation.mean:distribution/max': 0.0, 'image/Saturation.mean:distribution/min': 0.0, 'image/Saturation.mean:distribution/q_01': 0.0, 'image/Saturation.mean:distribution/q_05': 0.0, 'image/Saturation.mean:distribution/q_10': 0.0, 'image/Saturation.mean:distribution/q_25': 0.0, 'image/Saturation.mean:distribution/median': 0.0, 'image/Saturation.mean:distribution/q_75': 0.0, 'image/Saturation.mean:distribution/q_90': 0.0, 'image/Saturation.mean:distribution/q_95': 0.0, 'image/Saturation.mean:distribution/q_99': 0.0, 'image/Saturation.stddev:counts/n': 1, 'image/Saturation.stddev:counts/null': 0, 'image/Saturation.stddev:counts/nan': 0, 'image/Saturation.stddev:counts/inf': 0, 'image/Saturation.stddev:counts/true': 0, 'image/Saturation.stddev:types/integral': 0, 'image/Saturation.stddev:types/fractional': 1, 'image/Saturation.stddev:types/boolean': 0, 'image/Saturation.stddev:types/string': 0, 'image/Saturation.stddev:types/object': 0, 'image/Saturation.stddev:types/tensor': 0, 'image/Saturation.stddev:cardinality/est': 1.0, 'image/Saturation.stddev:cardinality/upper_1': 1.000049929250618, 'image/Saturation.stddev:cardinality/lower_1': 1.0, 'image/Saturation.stddev:distribution/mean': 0.0, 'image/Saturation.stddev:distribution/stddev': 0.0, 'image/Saturation.stddev:distribution/n': 1, 'image/Saturation.stddev:distribution/max': 0.0, 'image/Saturation.stddev:distribution/min': 0.0, 'image/Saturation.stddev:distribution/q_01': 0.0, 'image/Saturation.stddev:distribution/q_05': 0.0, 'image/Saturation.stddev:distribution/q_10': 0.0, 'image/Saturation.stddev:distribution/q_25': 0.0, 'image/Saturation.stddev:distribution/median': 0.0, 'image/Saturation.stddev:distribution/q_75': 0.0, 'image/Saturation.stddev:distribution/q_90': 0.0, 'image/Saturation.stddev:distribution/q_95': 0.0, 'image/Saturation.stddev:distribution/q_99': 0.0, 'image/Brightness.mean:counts/n': 1, 'image/Brightness.mean:counts/null': 0, 'image/Brightness.mean:counts/nan': 0, 'image/Brightness.mean:counts/inf': 0, 'image/Brightness.mean:counts/true': 0, 'image/Brightness.mean:types/integral': 0, 'image/Brightness.mean:types/fractional': 1, 'image/Brightness.mean:types/boolean': 0, 'image/Brightness.mean:types/string': 0, 'image/Brightness.mean:types/object': 0, 'image/Brightness.mean:types/tensor': 0, 'image/Brightness.mean:cardinality/est': 1.0, 'image/Brightness.mean:cardinality/upper_1': 1.000049929250618, 'image/Brightness.mean:cardinality/lower_1': 1.0, 'image/Brightness.mean:distribution/mean': 9.373138427734375, 'image/Brightness.mean:distribution/stddev': 0.0, 'image/Brightness.mean:distribution/n': 1, 'image/Brightness.mean:distribution/max': 9.373138427734375, 'image/Brightness.mean:distribution/min': 9.373138427734375, 'image/Brightness.mean:distribution/q_01': 9.373138427734375, 'image/Brightness.mean:distribution/q_05': 9.373138427734375, 'image/Brightness.mean:distribution/q_10': 9.373138427734375, 'image/Brightness.mean:distribution/q_25': 9.373138427734375, 'image/Brightness.mean:distribution/median': 9.373138427734375, 'image/Brightness.mean:distribution/q_75': 9.373138427734375, 'image/Brightness.mean:distribution/q_90': 9.373138427734375, 'image/Brightness.mean:distribution/q_95': 9.373138427734375, 'image/Brightness.mean:distribution/q_99': 9.373138427734375, 'image/Brightness.stddev:counts/n': 1, 'image/Brightness.stddev:counts/null': 0, 'image/Brightness.stddev:counts/nan': 0, 'image/Brightness.stddev:counts/inf': 0, 'image/Brightness.stddev:counts/true': 0, 'image/Brightness.stddev:types/integral': 0, 'image/Brightness.stddev:types/fractional': 1, 'image/Brightness.stddev:types/boolean': 0, 'image/Brightness.stddev:types/string': 0, 'image/Brightness.stddev:types/object': 0, 'image/Brightness.stddev:types/tensor': 0, 'image/Brightness.stddev:cardinality/est': 1.0, 'image/Brightness.stddev:cardinality/upper_1': 1.000049929250618, 'image/Brightness.stddev:cardinality/lower_1': 1.0, 'image/Brightness.stddev:distribution/mean': 13.016019647711326, 'image/Brightness.stddev:distribution/stddev': 0.0, 'image/Brightness.stddev:distribution/n': 1, 'image/Brightness.stddev:distribution/max': 13.016019647711326, 'image/Brightness.stddev:distribution/min': 13.016019647711326, 'image/Brightness.stddev:distribution/q_01': 13.016019647711326, 'image/Brightness.stddev:distribution/q_05': 13.016019647711326, 'image/Brightness.stddev:distribution/q_10': 13.016019647711326, 'image/Brightness.stddev:distribution/q_25': 13.016019647711326, 'image/Brightness.stddev:distribution/median': 13.016019647711326, 'image/Brightness.stddev:distribution/q_75': 13.016019647711326, 'image/Brightness.stddev:distribution/q_90': 13.016019647711326, 'image/Brightness.stddev:distribution/q_95': 13.016019647711326, 'image/Brightness.stddev:distribution/q_99': 13.016019647711326}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
     "# Submit Ray job using JobSubmissionClient\n",
     "client = JobSubmissionClient(ray_address)\n",
     "job_id = client.submit_job(\n",
     "    entrypoint=\"python mandlebrot.py\",\n",
     "    runtime_env={\n",
     "        \"working_dir\": \"./\",\n",
-    "        \"pip\": [\"piexif\",\"ipyplot\",\"whylogs[image,whylabs]\"],\n",
+    "        \"pip\": [\"piexif\",\"ipyplot\",\"whylogs[image,whylabs]\", \"matplotlib==3.9.0\"],\n",
     "        \"env_vars\": {\"http_proxy\":\"http://10.78.90.46:80\",\"https_proxy\":\"http://10.78.90.46:80\"}\n",
     "    },\n",
     "    entrypoint_num_cpus=3\n",
     ")\n",
     "\n",
-    "print(client.__dict__)\n",
     "print(f\"Ray job submitted with job_id: {job_id}\")\n",
     "\n",
-    "# Wait for a while to let the jobs run\n",
-    "time.sleep(1)\n",
-    "\n",
-    "job_status = client.get_job_status(job_id)\n",
-    "get_job_logs = client.get_job_logs(job_id)\n",
-    "get_job_info = client.get_job_info(job_id)\n",
-    "print(f\"Ray job status for job_id {job_id}: {job_status}\")\n",
-    "print(f\"Ray job logs for job_id {job_id}: {get_job_logs}\")\n",
-    "print(f\"Ray job info for job_id {job_id}: {get_job_info}\")\n",
-    "async for lines in client.tail_job_logs(job_id):\n",
-    "    print(lines, end=\"\") \n",
-    "\n",
-    "# Disconnect from the Ray cluster\n",
-    "ray.shutdown()"
+    "# Waiting for Ray to finish the job and print the result\n",
+    "while True:\n",
+    "    status = client.get_job_status(job_id)\n",
+    "    if status in [ray.job_submission.JobStatus.RUNNING, ray.job_submission.JobStatus.PENDING]:\n",
+    "        time.sleep(5)\n",
+    "    else:\n",
+    "        break\n",
+    "try:\n",
+    "    logs = client.get_job_logs(job_id) \n",
+    "    print(logs)\n",
+    "except RuntimeError as e:\n",
+    "    print(f\"Failed to get job logs, please check logs on ray dashboard \")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Ray",
+   "language": "python",
+   "name": "ray"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
**ROOT-CAUSE:**
We used to generate random images for the tutorial, and some of the generated types were not compatible, which resulted in the following error:
```
  File "/home/ray/anaconda3/lib/python3.11/site-packages/PIL/Image.py", line 3134, in fromarray
    raise TypeError(msg) from e
TypeError: Cannot handle this data type: (1, 1), |O
```
Please note that this issue did not occur in every run; it was likely related to how random image types were generated.

**SOLUTION:**
I have added additional checks while creating random images to avoid this issue:
```
                if img is not None:  # Check if img is valid
                    self._fractal_images.append(img)
```

Additionally, I have re-formatted the notebook file to print the logs properly.

**CHECKS:**
After implementing these changes, the job was successful multiple times:
![image](https://github.com/user-attachments/assets/83cacaef-521c-4f08-95f7-caf0aaeac619)
