### PR TITLE
EZAF-7178 Add base image in Kubeflow MNIST example

### DIFF
--- a/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
+++ b/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
@@ -379,7 +379,7 @@
     "# This function converts Katib Experiment HP results to args.\n",
     "\n",
     "from kfp import components\n",
-    "@dsl.component\n",
+    "@dsl.component(base_image=f\"{os.environ['AIRGAP_REGISTRY']}python:3.7\")\n",
     "def convert_katib_results(katib_results: dict) -> str:\n",
     "    import json\n",
     "    import pprint\n",

--- a/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
+++ b/Data-Science/Kubeflow/MNIST-Digits-Recognition/mnist_katib_tf_kserve_example.ipynb
@@ -379,7 +379,7 @@
     "# This function converts Katib Experiment HP results to args.\n",
     "\n",
     "from kfp import components\n",
-    "@dsl.component(base_image=f\"{os.environ['AIRGAP_REGISTRY']}python:3.7\")\n",
+    "@dsl.component(base_image=\"python:3.7\")\n",
     "def convert_katib_results(katib_results: dict) -> str:\n",
     "    import json\n",
     "    import pprint\n",


### PR DESCRIPTION
Without that base image user don't have a place to add airgap registry prefix to it.
In some future PR we could try to automate that process of adding airgap image prefix in notebook code and in yaml files.