### PR TITLE
Ezaf 8364 - Updating Airflow examples with latest Spark image

### DIFF
--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.1:v3.5.1.0.5'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_csv_to_parquet_fts.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataProcessTransfer/DataProcessTransfer.jar
   mainClass: com.mapr.sparkdemo.DataProcessTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
+++ b/Data-Engineering/Airflow/example_ezaf_spark_mnist.yaml
@@ -15,7 +15,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.1:v3.5.1.0.5'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   mainApplicationFile: local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/DataTransfer/DataTransfer.jar
   mainClass: com.mapr.sparkdemo.DataTransfer

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.1:v3.5.1.0.5'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}gcr.io/mapr-252711/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -11,7 +11,7 @@ spec:
   imagePullSecrets:
   - imagepull
   mainClass: org.apache.spark.examples.SparkPi
-  mainApplicationFile: "local:///opt/mapr/spark/spark-3.5.1/examples/jars/spark-examples_2.12-3.5.1.0-eep.jar"
+  mainApplicationFile: "local:///mounts/shared-volume/shared/ezua-tutorials/current-release/Data-Analytics/Spark/pi/pi.py"
   restartPolicy:
     type: Never
   driver:

--- a/Data-Engineering/Airflow/example_spark_pi.yaml
+++ b/Data-Engineering/Airflow/example_spark_pi.yaml
@@ -6,7 +6,7 @@ spec:
   type: Scala
   sparkVersion: 3.5.1
   mode: cluster
-  image: '{{dag_run.conf["airgap_registry_url"]|default("", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
+  image: '{{dag_run.conf["airgap_registry_url"]|default("lr1-bd-harbor-registry.mip.storage.hpecorp.net/develop/", True)}}hpe-spark/spark-3.5.2:v3.5.2.1.1'
   imagePullPolicy: Always
   imagePullSecrets:
   - imagepull


### PR DESCRIPTION
Updated the Airflow examples with the latest Spark image : spark-3.5.2:v3.5.2.1.1
Tested them on apps-gen-cluster02:
<img width="1673" alt="Screenshot 2025-02-05 at 11 15 05 AM" src="https://github.com/user-attachments/assets/b9b9518a-a0a2-4aaf-a84d-638d2d5889d9" />
<img width="1720" alt="Screenshot 2025-02-05 at 11 15 46 AM" src="https://github.com/user-attachments/assets/7e904413-1ac3-4cfd-8044-1230b02d4df2" />

<img width="1436" alt="Screenshot 2025-02-05 at 11 40 58 AM" src="https://github.com/user-attachments/assets/3edd46ea-d177-489e-92b6-15af85f9ea84" />
