### PR TITLE
EZAF-9586: Ray Tune example from aie-tutorials failed with FileNotFoundError: [Errno 2] No such file or directory

### DIFF
--- a/Data-Science/Ray/Ray-Tune/README.md
+++ b/Data-Science/Ray/Ray-Tune/README.md
@@ -8,7 +8,7 @@
 * Activate the Ray-specific Python kernel in your notebook environment.
 * To ensure optimal performance, use dedicated directories containing only the essential files needed for that job submission as a working directory. `json` data files are located in the `resources` directory.
 
-### Running Independent Tune Trials in Parallel https://docs.ray.io/en/releases-2.24.0/tune/tutorials/tune-run.html
+### Please see detailed explanation of the example in https://docs.ray.io/en/releases-2.24.0/tune/tutorials/tune-run.html
 
 
 

--- a/Data-Science/Ray/Ray-Tune/independent-tune-trials-example.py
+++ b/Data-Science/Ray/Ray-Tune/independent-tune-trials-example.py
@@ -6,6 +6,9 @@ import os
 
 NUM_MODELS = 5
 
+model_storage="/tmp/ray/tune_models"
+os.makedirs(model_storage, exist_ok=True)
+
 def train_model(config):
     score = config["model_id"]
 
@@ -34,7 +37,18 @@ trial_space = {
 train_model = tune.with_resources(train_model, {"cpu": 1})
 
 # Start a Tune run and print the best result.
-tuner = tune.Tuner(train_model, param_space=trial_space)
+tuner = tune.Tuner(
+    train_model, 
+    param_space=trial_space,
+    run_config=tune.RunConfig(
+        storage_path=model_storage,
+        name="independent_tune_experiment",
+        checkpoint_config=tune.CheckpointConfig(
+            checkpoint_frequency=0,
+            checkpoint_at_end=False
+        )
+    )
+)
 results = tuner.fit()
 
 # Access individual results.


### PR DESCRIPTION
**MOTIVATION**
Ray Tune tasks complete successfully, but storing the models fails. See: https://github.com/ray-project/ray/issues/52343
![2-42-1](https://github.com/user-attachments/assets/9cde6e6d-cc92-445a-9c40-0dde295ad0ef)

**SOLUTION**
Explicitly specifying the storage location allows models to be stored, but post-job actions still fail. As a result, the job status is marked as `FAILED`.
![models](https://github.com/user-attachments/assets/1fa2a560-4c12-49db-8302-da3e8eea0454)

This serves as a workaround until the community provides a permanent fix. We will be release note this behavior.